### PR TITLE
Change charms to use juju-http{s}-proxy model settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,11 @@
 
 This is a library layer for common functions that exist across the container
 runtimes.
+
+
+# Tests
+
+To run tests use:
+```
+python -m pytest ./tests
+```

--- a/config.yaml
+++ b/config.yaml
@@ -6,3 +6,9 @@ options:
        Enable GRUB cgroup overrides cgroup_enable=memory swapaccount=1. WARNING
        changing this option will reboot the host - use with caution on production
        services.
+  disable-juju-proxy:
+    type: boolean
+    default: false
+    description: |
+      Ignore juju-http(s) proxy settings on this charm.
+      If set to true, all juju https proxy settings will be ignored

--- a/lib/charms/layer/container_runtime_common.py
+++ b/lib/charms/layer/container_runtime_common.py
@@ -23,7 +23,7 @@ def get_hosts(config):
         for address in config.get('NO_PROXY', "").split(","):
             address = address.strip()
             try:
-                net = ipaddress.ip_network(address.strip())
+                net = ipaddress.ip_network(address)
                 ip_addresses = [str(ip) for ip in net.hosts()]
                 if ip_addresses == []:
                     hosts.append(address)

--- a/lib/charms/layer/container_runtime_common.py
+++ b/lib/charms/layer/container_runtime_common.py
@@ -59,7 +59,7 @@ def check_for_juju_https_proxy(config):
     charm_config = dict(config())
 
     if environment_config is None or \
-            charm_config.get('disable-proxy'):
+            charm_config.get('disable-juju-proxy'):
         return charm_config
 
     no_proxy = get_hosts(environment_config)

--- a/lib/charms/layer/container_runtime_common.py
+++ b/lib/charms/layer/container_runtime_common.py
@@ -47,7 +47,8 @@ def check_for_juju_https_proxy(config):
     no_proxy = get_hosts(environment_config)
 
     environment_config.update({
-        'NO_PROXY': no_proxy
+        'NO_PROXY': no_proxy,
+        'no_proxy': no_proxy
     })
     configuration.update(environment_config)
 

--- a/lib/charms/layer/container_runtime_common.py
+++ b/lib/charms/layer/container_runtime_common.py
@@ -36,23 +36,28 @@ def get_hosts(config):
 
 
 def merge_config(config, environment):
+    keys = ['HTTP_PROXY', 'HTTPS_PROXY', 'NO_PROXY']
 
-    for key in ['HTTP_PROXY', 'http_proxy', 'HTTPS_PROXY', 'https_proxy',
-                'NO_PROXY', 'no_proxy']:
-        # We make the assumption here that
-        # all environment keys are upper and lower case.
+    for key in keys:
         if config.get(key.lower(), '') == '' and \
-               config.get(key.upper(), '') == '' and environment.get(key, '') != '':
-            value = environment.get(key)
-            config[key.upper()] = value
-            config[key.lower()] = value
+            config.get(key, '') == '':
+            value = environment.get(key) if environment.get(key, '') != '' else environment.get(key.lower(), '')
+
+            if value != '':
+                config[key] = value
+                config[key.lower()] = value
+    # Normalize
+    for key in keys:
+        value = config.get(key) if config.get(key, '') != '' else config.get(key.lower(), '')
+        config[key] = value
+        config[key.lower()] = value
 
     return config
 
 
 def check_for_juju_https_proxy(config):
-    # If config values are defined take precedent.
-    # LP: https://bugs.launchpad.net/charm-layer-docker/+bug/1831712
+# If config values are defined take precedent.
+# LP: https://bugs.launchpad.net/charm-layer-docker/+bug/1831712
     environment_config = env_proxy_settings()
     charm_config = dict(config())
 

--- a/lib/charms/layer/container_runtime_common.py
+++ b/lib/charms/layer/container_runtime_common.py
@@ -51,10 +51,8 @@ def merge_config(config, environment):
 
 
 def check_for_juju_https_proxy(config):
-    # If juju environment variables are defined, take precedent
-    # over config.yaml.
-    # See: https://github.com/dshcherb/charm-helpers/blob/eba3742de6a7023f22778ba58fbbb0ac212d2ea6/charmhelpers/core/hookenv.py#L1455
-    # &: https://bugs.launchpad.net/charm-layer-docker/+bug/1831712
+    # If config values are defined take precedent.
+    # LP: https://bugs.launchpad.net/charm-layer-docker/+bug/1831712
     environment_config = env_proxy_settings()
     charm_config = dict(config())
 

--- a/lib/charms/layer/container_runtime_common.py
+++ b/lib/charms/layer/container_runtime_common.py
@@ -42,7 +42,7 @@ def merge_config(config, environment):
         # We make the assumption here that
         # all environment keys are upper and lower case.
         if config.get(key.lower(), '') == '' and \
-               config.get(key.upper()) == '' and environment.get(key, '') != '':
+               config.get(key.upper(), '') == '' and environment.get(key, '') != '':
             value = environment.get(key)
             config[key.upper()] = value
             config[key.lower()] = value

--- a/lib/charms/layer/container_runtime_common.py
+++ b/lib/charms/layer/container_runtime_common.py
@@ -32,7 +32,6 @@ def get_hosts(config):
             except ValueError:
                 hosts.append(address)
         parsed_hosts = ",".join(hosts)
-        print("Hosts: {}".format(parsed_hosts))
         return parsed_hosts
 
 

--- a/lib/charms/layer/container_runtime_common.py
+++ b/lib/charms/layer/container_runtime_common.py
@@ -41,7 +41,10 @@ def check_for_juju_https_proxy(config):
     # See: https://github.com/dshcherb/charm-helpers/blob/eba3742de6a7023f22778ba58fbbb0ac212d2ea6/charmhelpers/core/hookenv.py#L1455
     # &: https://bugs.launchpad.net/charm-layer-docker/+bug/1831712
     environment_config = env_proxy_settings()
-    configuration = dict(config())
+    modified_config = dict(config())
+
+    if environment_config is None:
+        return modified_config
 
     no_proxy = get_hosts(environment_config)
 
@@ -49,9 +52,9 @@ def check_for_juju_https_proxy(config):
         'NO_PROXY': no_proxy,
         'no_proxy': no_proxy
     })
-    configuration.update(environment_config)
+    modified_config.update(environment_config)
 
-    return configuration
+    return modified_config
 
 
 def manage_registry_certs(cert_dir, remove=False):

--- a/lib/charms/layer/container_runtime_common.py
+++ b/lib/charms/layer/container_runtime_common.py
@@ -58,7 +58,8 @@ def check_for_juju_https_proxy(config):
     environment_config = env_proxy_settings()
     charm_config = dict(config())
 
-    if environment_config is None:
+    if environment_config is None or \
+            charm_config.get('disable-proxy'):
         return charm_config
 
     no_proxy = get_hosts(environment_config)

--- a/tests/test_cidr_notation.py
+++ b/tests/test_cidr_notation.py
@@ -1,0 +1,16 @@
+import pytest
+from lib.charms.layer.container_runtime_common import (
+    get_hosts
+)
+
+
+def test_get_hosts():
+    CONFIG = {
+        'NO_PROXY': "192.168.2.1, 192.168.2.0/29, hello.com"
+    }
+
+    hosts = get_hosts(CONFIG)
+
+    assert hosts == "192.168.2.1,192.168.2.1,\
+192.168.2.2,192.168.2.3,192.168.2.4,192.168.2.5,\
+192.168.2.6,hello.com"

--- a/tests/test_cidr_notation.py
+++ b/tests/test_cidr_notation.py
@@ -14,3 +14,13 @@ def test_get_hosts():
     assert hosts == "192.168.2.1,192.168.2.1,\
 192.168.2.2,192.168.2.3,192.168.2.4,192.168.2.5,\
 192.168.2.6,hello.com"
+
+
+def test_return_conf():
+    CONFIG = {
+        'NO_PROXY': ""
+    }
+
+    hosts = get_hosts(CONFIG)
+
+    assert hosts == ""

--- a/tests/test_merge_config.py
+++ b/tests/test_merge_config.py
@@ -21,9 +21,11 @@ def test_get_hosts():
 
     assert merged == {
         'NO_PROXY': '192.168.2.1, 192.168.2.0/29, hello.com',
+        'HTTPS_PROXY': 'https://hop.proxy',
+        'HTTP_PROXY': 'http://proxy.hop',
+        'no_proxy': '192.168.2.1, 192.168.2.0/29, hello.com',
         'https_proxy': 'https://hop.proxy',
-        'http_proxy': 'http://proxy.hop',
-        'HTTP_PROXY': 'http://proxy.hop'
+        'http_proxy': 'http://proxy.hop'
     }
 
 
@@ -43,10 +45,10 @@ def test_get_hosts_no_local_conf():
 
     assert merged == {
         'HTTPS_PROXY': 'https://proxy.hop',
-        'https_proxy': 'https://proxy.hop',
         'HTTP_PROXY': 'http://proxy.hop',
-        'http_proxy': 'http://proxy.hop',
         'NO_PROXY': 'not tha proxy',
+        'https_proxy': 'https://proxy.hop',
+        'http_proxy': 'http://proxy.hop',
         'no_proxy': 'not tha proxy'
     }
 
@@ -54,9 +56,8 @@ def test_get_hosts_no_local_conf():
 def test_get_hosts_no_env_conf():
     ENVIRONMENT = {
         'NO_PROXY': '',
-        'https_proxy': '',
+        'HTTPS_PROXY': '',
         'HTTP_PROXY': '',
-
     }
     CONFIG = {
         'HTTPS_PROXY': 'https://proxy.hop',
@@ -69,5 +70,8 @@ def test_get_hosts_no_env_conf():
     assert merged == {
         'HTTPS_PROXY': 'https://proxy.hop',
         'HTTP_PROXY': 'http://proxy.hop',
-        'no_proxy': 'not tha proxy'
+        'NO_PROXY': 'not tha proxy',
+        'no_proxy': 'not tha proxy',
+        'https_proxy': 'https://proxy.hop',
+        'http_proxy': 'http://proxy.hop',
     }

--- a/tests/test_merge_config.py
+++ b/tests/test_merge_config.py
@@ -1,0 +1,28 @@
+import pytest
+from lib.charms.layer.container_runtime_common import (
+    merge_config
+)
+
+
+def test_get_hosts():
+    CONFIG = {
+        'NO_PROXY': '192.168.2.1, 192.168.2.0/29, hello.com',
+        'https_proxy': 'https://hop.proxy',
+        'HTTP_PROXY': '',
+
+    }
+    ENVIRONMENT = {
+        'HTTPS_PROXY': 'https://proxy.hop',
+        'HTTP_PROXY': 'http://proxy.hop',
+        'NO_PROXY': '',
+        'no_proxy': 'not tha proxy'
+    }
+
+    merged = merge_config(CONFIG, ENVIRONMENT)
+
+    assert merged == {
+        'NO_PROXY': '192.168.2.1, 192.168.2.0/29, hello.com',
+        'https_proxy': 'https://hop.proxy',
+        'http_proxy': 'http://proxy.hop',
+        'HTTP_PROXY': 'http://proxy.hop'
+    }

--- a/tests/test_merge_config.py
+++ b/tests/test_merge_config.py
@@ -32,7 +32,6 @@ def test_get_hosts_no_local_conf():
         'NO_PROXY': '',
         'https_proxy': '',
         'HTTP_PROXY': '',
-
     }
     ENVIRONMENT = {
         'HTTPS_PROXY': 'https://proxy.hop',
@@ -48,5 +47,27 @@ def test_get_hosts_no_local_conf():
         'HTTP_PROXY': 'http://proxy.hop',
         'http_proxy': 'http://proxy.hop',
         'NO_PROXY': 'not tha proxy',
+        'no_proxy': 'not tha proxy'
+    }
+
+
+def test_get_hosts_no_env_conf():
+    ENVIRONMENT = {
+        'NO_PROXY': '',
+        'https_proxy': '',
+        'HTTP_PROXY': '',
+
+    }
+    CONFIG = {
+        'HTTPS_PROXY': 'https://proxy.hop',
+        'HTTP_PROXY': 'http://proxy.hop',
+        'no_proxy': 'not tha proxy'
+    }
+
+    merged = merge_config(CONFIG, ENVIRONMENT)
+
+    assert merged == {
+        'HTTPS_PROXY': 'https://proxy.hop',
+        'HTTP_PROXY': 'http://proxy.hop',
         'no_proxy': 'not tha proxy'
     }

--- a/tests/test_merge_config.py
+++ b/tests/test_merge_config.py
@@ -14,7 +14,6 @@ def test_get_hosts():
     ENVIRONMENT = {
         'HTTPS_PROXY': 'https://proxy.hop',
         'HTTP_PROXY': 'http://proxy.hop',
-        'NO_PROXY': '',
         'no_proxy': 'not tha proxy'
     }
 
@@ -25,4 +24,29 @@ def test_get_hosts():
         'https_proxy': 'https://hop.proxy',
         'http_proxy': 'http://proxy.hop',
         'HTTP_PROXY': 'http://proxy.hop'
+    }
+
+
+def test_get_hosts_no_local_conf():
+    CONFIG = {
+        'NO_PROXY': '',
+        'https_proxy': '',
+        'HTTP_PROXY': '',
+
+    }
+    ENVIRONMENT = {
+        'HTTPS_PROXY': 'https://proxy.hop',
+        'HTTP_PROXY': 'http://proxy.hop',
+        'no_proxy': 'not tha proxy'
+    }
+
+    merged = merge_config(CONFIG, ENVIRONMENT)
+
+    assert merged == {
+        'HTTPS_PROXY': 'https://proxy.hop',
+        'https_proxy': 'https://proxy.hop',
+        'HTTP_PROXY': 'http://proxy.hop',
+        'http_proxy': 'http://proxy.hop',
+        'NO_PROXY': 'not tha proxy',
+        'no_proxy': 'not tha proxy'
     }


### PR DESCRIPTION
Changed charm to use juju-http{s}-proxy-settings when these keys are defined.

[LP#1831712](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/1831712)